### PR TITLE
Fix typewriter animation queue clearing

### DIFF
--- a/JS/main.js
+++ b/JS/main.js
@@ -203,7 +203,7 @@ function readText(){
 
 function writeQuestion(question) {
   if(typewriter!=null) {
-    typewriter.stop();
+      typewriter.state.eventQueue = [];
     $('#textdiv span').first().text('');
   } else {
     typewriter = new Typewriter(document.getElementById('textdiv'), {


### PR DESCRIPTION
This fixes issue #41 

When clicking the next or previous button, the typewriter.stop() function was called. Unfortunately it didn't do anything / didn't stop the animation. Instead it kinda paused it and continued typing the letters of all previous questions.

To fixed this, I tried to understand what the typewriter.stop() was supposed to do and realized that clearing the animation queue manually works.