### PR TITLE
[closes #434] Minimal support for response timing

### DIFF
--- a/CSS/main.css
+++ b/CSS/main.css
@@ -189,5 +189,5 @@ div .arrows{
   background: lightblue;
   padding: 1em;
   border-radius: 4px;
-  margin: -1em 1em 0em 1em;
+  margin: -1.5em 1em 0em 1em;
 }

--- a/CSS/main.css
+++ b/CSS/main.css
@@ -178,3 +178,16 @@ div .arrows{
 .on {
   display: none;
 }
+
+.timing-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+.timing-entry {
+  background: lightblue;
+  padding: 1em;
+  border-radius: 4px;
+  margin: -1em 1em 0em 1em;
+}

--- a/JS/history.js
+++ b/JS/history.js
@@ -1,0 +1,99 @@
+// global reference to the history; shouldn't be directly accessed outside
+// this file.
+//
+// If we are using a remote backend cache the value here for easy access once
+// we've done an initial retrieval
+var _history = null;
+
+// this tracks if we're using local storage or some remote user system to
+// keep timing data
+var _historyUsesLocalStorage = true;
+
+// the key we store timing data under when in local storage mode
+var _historyKey = 'response_history';
+
+///////////////////////////////////////////////////////////////////////////////
+
+// If we are storing things remotely the code to get them goes here
+function getRemoteHistory() {
+    console.error('User accounts not yet implemented.');
+    return null;
+}
+
+// as above except saving
+function saveRemoteHistory() {
+    console.error('User accounts not yet implementhed.');
+    return false;
+}
+
+// ensures that history has been loaded; returns true on success
+function loadHistory() {
+    if (_history !== null) {
+        return true;
+    }
+
+    if (!_historyUsesLocalStorage) {
+        var history = getRemoteHistory();
+        if (history === null) {
+            console.error('Falling back to local history');
+        } else {
+            _history = history;
+            return true;
+        }
+    }
+
+    var history = localStorage.getItem(_historyKey);
+    if (history == null) {
+        localStorage.setItem(_historyKey, JSON.stringify({}));
+        history = "{}";
+    }
+    _history = JSON.parse(history);
+    return true;
+}
+
+// saves history; returns true on success
+function saveHistory() {
+    if (!_historyUsesLocalStorage) {
+        if (saveRemoteHistory()) {
+            return true;
+        }
+        console.error('Falling back to local history');
+    }
+
+    localStorage.setItem(_historyKey, JSON.stringify(_history));
+    return true;
+}
+
+// clears historic timing data and saves the cleared state; returns true on
+// success
+function clearHistory() {
+    _history = {};
+    return saveHistory();
+}
+
+// returns an array with timing data for a given question number
+function getHistory(questionNo) {
+    if (!loadHistory()) {
+        console.error('Unable to load history for question ' + questionNo);
+        return [];
+    }
+    
+    var record = _history[questionNo];
+    return !!record ? record : [];
+}
+
+// record the time taken to answer a given question based on the question
+// number
+function recordAnswer(questionNo, timeSpentMS) {
+    if (!loadHistory()) {
+        console.error('Unable to record new time for question ' + questionNo);
+        return false;
+    }
+
+    // check for existing timing data, initialize if none found
+    if (!_history[questionNo]) {
+        _history[questionNo] = [];
+    }
+    _history[questionNo].push(timeSpentMS);
+    return true;
+}

--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
     <script src="https://unpkg.com/typewriter-effect/dist/core.js"></script>
-    <script src="JS/confetti.js"></script>	
-    <script src="JS/main.js"></script>	
+    <script src="JS/confetti.js"></script>
+    <script src="JS/history.js"></script>
+    <script src="JS/main.js"></script>
     <div class="container">
       <div id="top">
         <div id="read">
@@ -22,6 +23,11 @@
         </div>
         <a class="cheatsheet" href="cheatsheet.html">Cheat Sheet</a>
         <div id="confetti"></div>
+      </div>
+      <div id="timings" class="timing-container">
+        <div id="timing-0" class="timing-entry"></div>
+        <div id="timing-1" class="timing-entry"></div>
+        <div id="timing-2" class="timing-entry"></div>
       </div>
       <div id="bottom">
         <ul id="keyboard">


### PR DESCRIPTION
### Context

Per #434 we wanted to add response time tracking to the keyboard shortcut app.`

### How it works

When we display a new question the current time is captured (in `questionStartMS`). When a question is successfully answered we record the delta between now and when the question was asked. When we ask a question a lookup is done to find the recorded timings and the most recent 3 are displayed inline below the question area.

Timing data is stored by default in local storage and keyed by the question number. This has some problems in the event that the shortcut question list changes but the overhead of maintaining a unique id seemed higher than the problems resulting from changing the order of the questions.

Since I saw that folks had been thinking about user accounts we can set `_historyUsesLocalStorage` to `false` in `history.js`. This will result in a call to get/save timing data on a remote store. These functions print an error and it falls back to local storage until we have an user system implemented.

### TODO

We could 100% make the presentation of the recent timing data prettier but I timeboxed this to the duration of the event figuring we could track future work in additional issues 😄.