### PR TITLE
docs: Resolve a typo with commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,14 @@ Prepare for contributing by following these beginner-friendly steps.
 1. Run `git checkout backend` to go to the backend feature branch. This is the *only* branch that we will be working in.
 1. Follow [the steps to run the project locally](/README.md/#running-the-project).
 1. Run `git remote add upstream https://github.com/Techtonica/keyboard-shortcuts-practice.git`.  This is so that you can refer to the original project owned by Techtonica as the `upstream` version.
-1. Run `git remove -v` to test that you can get updates from Techtonica's repo. [You should see something like this](https://github.com/anitab-org/mentorship-android/wiki/Fork,-Clone-&-Remote#remote). If it shows an error that you don't have permission, contact a Tectonica admin. You can still get started without this part, but you'll need it soon.
+1. Run `git remote -v` to test that you can get updates from Techtonica's repo. [You should see something like this](https://github.com/anitab-org/mentorship-android/wiki/Fork,-Clone-&-Remote#remote). If it shows an error that you don't have permission, contact a Tectonica admin. You can still get started without this part, but you'll need it soon.
 
 ### Get started
 1. Choose an issue in the "To Do" column of [this board](https://github.com/Techtonica/keyboard-shortcuts-practice/projects/4).
 1. Leave a comment that you would like to pick up the issue.
 1. Read the description, and make sure to ask questions about anything that is unclear.
 1. Start on your forked repo's `backend` branch with `git checkout backend`.
-1. Make sure you have the latest version of the project with `git pull upstream/backend`.
+1. Make sure you have the latest version of the project with `git pull upstream backend` or `git merge upstream/backend`.
 1. Create a new branch with `git checkout -b <new-branch-name>`. The name should include the issue number and the topic you're working in.  For example, if its about adding a GET request, your command could be `git checkout -b add-get-request`.
 1. Make and commit your changes on this new branch, and make a PR when you're ready. [Here are some directions on the process](http://www.dasblinkenlichten.com/how-to-create-a-github-pull-request-pr/).
 1. When creating your PR, be sure to make your pull request to the `backend` feature branch: 


### PR DESCRIPTION
This PR resolves a typo with some commands in the text of the CONTRIBUTION file.

The first one is in the Prerequisites steps, I changed this `git remove -v` to `git remote -v`
The second one is because when I am doing the Get started steps I had an error, specifically this error 
![image](https://user-images.githubusercontent.com/9274112/93242173-627e9d80-f754-11ea-97a1-9c4f9951eb6b.png)

After the googling, I found there are many ways to maintain project fork sync, but it was not with that command. I changed the command for the most used according to GitHub docs [link](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork) and [this](https://gist.github.com/CristinaSolana/1885435).

I hope that the creation of this PR follows the guidelines of the project, I also await any review.

Regards