### PR TITLE
Add highlight for Fn key in case F1-F12 is pressed. Fixes #29

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -109,6 +109,11 @@ function handle(e) {
     }
     $("#"+keyString.toLowerCase()).toggleClass("pressed");
   }
+  // Highlight Fn key if any of F1-F12 is pressed
+  if (e.which>=112 && e.which<=123) {
+    $("#"+e.key.toLowerCase()).addClass("pressed");
+    $("#fnc").addClass("pressed");
+  }
   if(e.key.toLowerCase()=="capslock" && caps==false){
     caps= true;
     $("#"+e.key.toLowerCase()).toggleClass("pressed");
@@ -118,11 +123,6 @@ function handle(e) {
     $("#"+e.key.toLowerCase()).toggleClass("pressed");
     $('.letter').toggleClass('uppercase');
     caps=false;
-  }
-  // Highlight Fn key if any of F1-F12 is pressed
-  else if (e.which>=112 && e.which<=123) {
-    $("#"+e.key.toLowerCase()).addClass("pressed");
-    $("#fnc").addClass("pressed");
   }
   else {
     if (commandDown) {
@@ -158,6 +158,11 @@ function release(e) {
   if(e.code.toLowerCase()=="space"){
     if(document.querySelector("#space"))
       document.querySelector("#space").classList.remove("pressed");
+  }
+  // Uhighlight Fn key if any of F1-F12 is pressed
+  if (e.which>=112 && e.which<=123) {
+    $("#"+e.key.toLowerCase()).removeClass("pressed");
+    $("#fnc").removeClass("pressed");
   }
   if(e.key.toLowerCase()=="capslock"){
     $("#"+e.key.toLowerCase()).toggleClass("pressed");

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -111,8 +111,8 @@ function handle(e) {
   }
   // Highlight Fn key if any of F1-F12 is pressed
   if (e.which>=112 && e.which<=123) {
-    $("#"+e.key.toLowerCase()).addClass("pressed");
-    $("#fnc").addClass("pressed");
+    document.querySelector("#"+e.key.toLowerCase()).classList.add("pressed");
+    document.querySelector("#fnc").classList.add("pressed");
   }
   if(e.key.toLowerCase()=="capslock" && caps==false){
     caps= true;
@@ -161,8 +161,8 @@ function release(e) {
   }
   // Uhighlight Fn key if any of F1-F12 is pressed
   if (e.which>=112 && e.which<=123) {
-    $("#"+e.key.toLowerCase()).removeClass("pressed");
-    $("#fnc").removeClass("pressed");
+    document.querySelector("#"+e.key.toLowerCase()).classList.remove("pressed");
+    document.querySelector("#fnc").classList.remove("pressed");
   }
   if(e.key.toLowerCase()=="capslock"){
     $("#"+e.key.toLowerCase()).toggleClass("pressed");
@@ -189,13 +189,13 @@ function promptKey2(key){
       $($('li[data-keycode="'+key+'"]')[0]).addClass("prompt");
       // Highlight Fn to be a combination with F1-F12
       if (key>=112 && key <=123) {
-        $($('li[data-keycode="fn"]')[0]).addClass("prompt");
+        document.querySelector("#fnc").classList.add("prompt");
       }
     } else {
       $($('li[data-keycode="'+key+'"]')[0]).removeClass("prompt")
       // Remove Fn highlight
       if (key>=112 && key <=123) {
-        $($('li[data-keycode="fn"]')[0]).removeClass("prompt");
+        document.querySelector("#fnc").classList.remove("prompt");
       }
     }
   //}

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -119,6 +119,11 @@ function handle(e) {
     $('.letter').toggleClass('uppercase');
     caps=false;
   }
+  // Highlight Fn key if any of F1-F12 is pressed
+  else if (e.which>=112 && e.which<=123) {
+    $("#"+e.key.toLowerCase()).addClass("pressed");
+    $("#fnc").addClass("pressed");
+  }
   else {
     if (commandDown) {
       e.preventDefault();
@@ -176,9 +181,17 @@ function highlightNextKey(params){
 function promptKey2(key){
   //if($('li[data-keycode="'+key+'"]'[0]).hasClass('prompt')){
     if (isShowHint) {
-      $($('li[data-keycode="'+key+'"]')[0]).addClass("prompt")
+      $($('li[data-keycode="'+key+'"]')[0]).addClass("prompt");
+      // Highlight Fn to be a combination with F1-F12
+      if (key>=112 && key <=123) {
+        $($('li[data-keycode="fn"]')[0]).addClass("prompt");
+      }
     } else {
       $($('li[data-keycode="'+key+'"]')[0]).removeClass("prompt")
+      // Remove Fn highlight
+      if (key>=112 && key <=123) {
+        $($('li[data-keycode="fn"]')[0]).removeClass("prompt");
+      }
     }
   //}
 }

--- a/public/scripts/shortcuts.json
+++ b/public/scripts/shortcuts.json
@@ -1,11 +1,5 @@
 [
   {
-    "answer": "F2",
-    "question": "How do you rename a symbol in VSCode?",
-    "keys": [113],
-    "shortcutType": "mac vscode"
-  },
-  {
     "answer": "command+x",
     "question": "How do you cut the selected item and copy it to the clipboard?",
     "keys": [91, 88],
@@ -196,5 +190,11 @@
     "question": "How do you open preferences for the front app?",
     "keys": [91, 188], 
     "shortcutType": "mac"
+  },
+  {
+    "answer": "F2",
+    "question": "How do you rename a symbol in VSCode?",
+    "keys": [113],
+    "shortcutType": "mac vscode"
   }
 ]

--- a/public/scripts/shortcuts.json
+++ b/public/scripts/shortcuts.json
@@ -1,5 +1,11 @@
 [
   {
+    "answer": "F2",
+    "question": "How do you rename a symbol in VSCode?",
+    "keys": [113],
+    "shortcutType": "mac vscode"
+  },
+  {
     "answer": "command+x",
     "question": "How do you cut the selected item and copy it to the clipboard?",
     "keys": [91, 88],


### PR DESCRIPTION
According to all mentioned above links, and especially this one - https://superuser.com/a/432622, OS do not see specific scancode for Fn key. It's only possible to see the scancode of combination Fn and F1-F12. 
So, there is no possibility to highlight the Fn key separately while it pressed.

As a possible solution, I've added highlighting of the Fn key if any of F1-F12 codes are received(=Fn+F1-12 are already pressed together.) 
<img src="https://user-images.githubusercontent.com/4979096/95416983-cbd37580-08e8-11eb-88b1-384937102884.png" width="400">
Also, I've added Fn highlighting to hints.
<img src="https://user-images.githubusercontent.com/4979096/95416974-c24a0d80-08e8-11eb-9ea8-de589bced42b.png" width="400">
For testing purposes I've added "How do you rename a symbol in VSCode?" shortcut to shortcut.json.

The only issue I have with F11 on MacOS - it can't be received by Browser, on Windows works well.

